### PR TITLE
fix: activate pane on focus

### DIFF
--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -20,8 +20,8 @@ describe("TerminalElement", () => {
   const createNewElement = async (uri = "atomic-terminal://somesessionid/") => {
     const terminalsSet = new Set()
     const model = new TerminalModel({
-      uri: uri,
-      terminalsSet: terminalsSet,
+      uri,
+      terminalsSet,
     })
     await model.initializedPromise
     model.pane = jasmine.createSpyObj("pane", ["removeItem", "getActiveItem", "destroyItem"])

--- a/spec/element-spec.js
+++ b/spec/element-spec.js
@@ -544,12 +544,18 @@ describe("TerminalElement", () => {
     spyOn(element.model, "setActive")
     element.focusOnTerminal()
     expect(element.model.setActive).toHaveBeenCalled()
-    expect(element.terminal.focus).toHaveBeenCalled()
+    expect(element.terminal.focus).toHaveBeenCalledTimes(1)
   })
 
   it("focusOnTerminal() terminal not set", () => {
     element.terminal = null
     element.focusOnTerminal()
+  })
+
+  it("focusOnTerminal(true) calls focus twice", () => {
+    spyOn(element.terminal, "focus")
+    element.focusOnTerminal(true)
+    expect(element.terminal.focus).toHaveBeenCalledTimes(2)
   })
 
   it("on 'data' handler no custom title on win32 platform", async () => {

--- a/spec/model-spec.js
+++ b/spec/model-spec.js
@@ -17,7 +17,7 @@ describe("TerminalModel", () => {
     terminalsSet = new Set()
     model = new TerminalModel({ uri, terminalsSet })
     await model.initializedPromise
-    pane = jasmine.createSpyObj("pane", ["destroyItem", "getActiveItem"])
+    pane = jasmine.createSpyObj("pane", ["destroyItem", "getActiveItem", "activateItem"])
     element = jasmine.createSpyObj("element", [
       "destroy",
       "refitTerminal",
@@ -304,6 +304,19 @@ describe("TerminalModel", () => {
     spyOn(model.emitter, "emit")
     model.focusOnTerminal()
     expect(model.emitter.emit).toHaveBeenCalled()
+  })
+
+  it("focusOnTerminal() activates the pane item", () => {
+    model.element = element
+    model.pane = pane
+    model.focusOnTerminal()
+    expect(model.pane.activateItem).toHaveBeenCalledWith(model)
+  })
+
+  it("focusOnTerminal() passes along double", () => {
+    model.element = element
+    model.focusOnTerminal(true)
+    expect(model.element.focusOnTerminal).toHaveBeenCalledWith(true)
   })
 
   it("exit()", () => {

--- a/spec/model-spec.js
+++ b/spec/model-spec.js
@@ -362,14 +362,14 @@ describe("TerminalModel", () => {
     const activePane = atom.workspace.getCenter().getActivePane()
     const newTerminalsSet = new Set()
     const model1 = new TerminalModel({
-      uri: uri,
+      uri,
       terminalsSet: newTerminalsSet,
     })
     await model1.initializedPromise
     activePane.addItem(model1)
     model1.setNewPane(activePane)
     const model2 = new TerminalModel({
-      uri: uri,
+      uri,
       terminalsSet: newTerminalsSet,
     })
     await model2.initializedPromise

--- a/src/element.ts
+++ b/src/element.ts
@@ -346,10 +346,14 @@ export class AtomTerminal extends HTMLElement {
     }
   }
 
-  focusOnTerminal() {
+  focusOnTerminal(double = false) {
     if (this.terminal && this.model) {
       this.model.setActive()
       this.terminal.focus()
+			if (double) {
+				// second focus will send command to pty
+				this.terminal.focus()
+			}
     }
   }
 

--- a/src/element.ts
+++ b/src/element.ts
@@ -313,9 +313,9 @@ export class AtomTerminal extends HTMLElement {
         })
       }
     } catch (err) {
-      let message = "Launching '" + this.ptyProcessCommand + "' raised the following error: " + err.message
+      let message = `Launching '${this.ptyProcessCommand}' raised the following error: ${err.message}`
       if (err.message.startsWith("File not found:")) {
-        message = "Could not open shell '" + this.ptyProcessCommand + "'."
+        message = `Could not open shell '${this.ptyProcessCommand}'.`
       }
       atom.notifications.addError("Terminal Error", { detail: message })
       if (this.model) {
@@ -350,10 +350,10 @@ export class AtomTerminal extends HTMLElement {
     if (this.terminal && this.model) {
       this.model.setActive()
       this.terminal.focus()
-			if (double) {
-				// second focus will send command to pty
-				this.terminal.focus()
-			}
+      if (double) {
+        // second focus will send command to pty
+        this.terminal.focus()
+      }
     }
   }
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -132,7 +132,7 @@ export class TerminalModel {
     if (this.title === DEFAULT_TITLE) {
       return DEFAULT_TITLE
     }
-    return DEFAULT_TITLE + " (" + this.title + ")"
+    return `${DEFAULT_TITLE} (${this.title})`
   }
 
   onDidChangeTitle(callback: (value?: string) => void) {
@@ -188,7 +188,7 @@ export class TerminalModel {
   focusOnTerminal(double = false) {
     if (this.element) {
       if (this.pane) {
-        this.pane.activateItem(this);
+        this.pane.activateItem(this)
       }
       this.element.focusOnTerminal(double)
       const oldIsModified = this.modified

--- a/src/model.ts
+++ b/src/model.ts
@@ -185,9 +185,12 @@ export class TerminalModel {
     }
   }
 
-  focusOnTerminal() {
+  focusOnTerminal(double = false) {
     if (this.element) {
-      this.element.focusOnTerminal()
+      if (this.pane) {
+        this.pane.activateItem(this);
+      }
+      this.element.focusOnTerminal(double)
       const oldIsModified = this.modified
       this.modified = false
       if (oldIsModified !== this.modified) {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -37,7 +37,7 @@ class Terminal {
       atom.workspace.addOpener((uri) => {
         if (uri.startsWith(TERMINAL_BASE_URI)) {
           const item = new TerminalModel({
-            uri: uri,
+            uri,
             terminalsSet: this.terminalsSet,
           })
           return item
@@ -218,7 +218,7 @@ class Terminal {
   }
 
   generateNewUri() {
-    return TERMINAL_BASE_URI + uuidv4() + "/"
+    return `${TERMINAL_BASE_URI + uuidv4()}/`
   }
 
   /**

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -423,7 +423,7 @@ class Terminal {
   async focus() {
     const terminal = [...this.terminalsSet].find((t) => t.activeIndex === 0)
     if (terminal) {
-      terminal.focusOnTerminal()
+      terminal.focusOnTerminal(true)
     } else {
       const options = this.addDefaultPosition()
       await this.open(this.generateNewUri(), options)


### PR DESCRIPTION
Currently atomic-terminal:focus won't make the dock visible if it is hidden.

This also fixes a problem where the pane is focused but xterm won't accept input until it is focused again.