### PR TITLE
fix: add terminal syntax variables to standard theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@
 
 ![Terminal demo](https://cdn.statically.io/gh/bus-stop/x-terminal/master/resources/x-terminal-demo.gif)
 
+## Theme variables
+
+The following theme variables are available to change the colors of the standard theme:
+
+```less
+@app-background-color: #000000;
+@text-color: #ffffff;
+@background-color-selected: #4d4d4d;
+@text-color-highlight: #ffffff;
+@terminal-color-black: #2e3436;
+@terminal-color-red: #cc0000;
+@terminal-color-green: #4e9a06;
+@terminal-color-yellow: #c4a000;
+@terminal-color-blue: #3465a4;
+@terminal-color-magenta: #75507b;
+@terminal-color-cyan: #06989a;
+@terminal-color-white: #d3d7cf;
+@terminal-color-bright-black: #555753;
+@terminal-color-bright-red: #ef2929;
+@terminal-color-bright-green: #8ae234;
+@terminal-color-bright-yellow: #fce94f;
+@terminal-color-bright-blue: #729fcf;
+@terminal-color-bright-magenta: #ad7fa8;
+@terminal-color-bright-cyan: #34e2e2;
+@terminal-color-bright-white: #eeeeec;
+```
+
 ## Active Terminal
 
 The active terminal is the terminal that will be used when sending commands to

--- a/spec/themes-spec.js
+++ b/spec/themes-spec.js
@@ -684,12 +684,33 @@ describe("themes", () => {
 
     it("Standard", () => {
       atom.config.set("atomic-terminal.colors.theme", "Standard")
-      const root = getComputedStyle(document.documentElement)
+      const { style } = document.documentElement
+      style.setProperty("--standard-app-background-color", "#000000")
+      style.setProperty("--standard-text-color", "#ffffff")
+      style.setProperty("--standard-background-color-selected", "#4d4d4d")
+      style.setProperty("--standard-text-color-highlight", "#ffffff")
+      style.setProperty("--standard-color-black", "#2e3436")
+      style.setProperty("--standard-color-red", "#cc0000")
+      style.setProperty("--standard-color-green", "#4e9a06")
+      style.setProperty("--standard-color-yellow", "#c4a000")
+      style.setProperty("--standard-color-blue", "#3465a4")
+      style.setProperty("--standard-color-magenta", "#75507b")
+      style.setProperty("--standard-color-cyan", "#06989a")
+      style.setProperty("--standard-color-white", "#d3d7cf")
+      style.setProperty("--standard-color-bright-black", "#555753")
+      style.setProperty("--standard-color-bright-red", "#ef2929")
+      style.setProperty("--standard-color-bright-green", "#8ae234")
+      style.setProperty("--standard-color-bright-yellow", "#fce94f")
+      style.setProperty("--standard-color-bright-blue", "#729fcf")
+      style.setProperty("--standard-color-bright-magenta", "#ad7fa8")
+      style.setProperty("--standard-color-bright-cyan", "#34e2e2")
+      style.setProperty("--standard-color-bright-white", "#eeeeec")
+
       expect(getTheme()).toEqual({
-        background: root.getPropertyValue("--standard-app-background-color"),
-        foreground: root.getPropertyValue("--standard-text-color"),
-        selection: root.getPropertyValue("--standard-background-color-selected"),
-        cursor: root.getPropertyValue("--standard-text-color-highlight"),
+        background: "#000000",
+        foreground: "#ffffff",
+        selection: "#4d4d4d",
+        cursor: "#ffffff",
         cursorAccent: "#000000",
         black: "#2e3436",
         red: "#cc0000",

--- a/src/config.ts
+++ b/src/config.ts
@@ -148,7 +148,7 @@ export const config = configOrder({
           "Solid Colors",
           "Standard",
         ],
-        default: "Custom",
+        default: "Standard",
       },
       // TODO: add transparency settings?
       foreground: {

--- a/src/element.ts
+++ b/src/element.ts
@@ -361,6 +361,13 @@ export class AtomTerminal extends HTMLElement {
       return this.terminal.clear()
     }
   }
+
+  updateTheme() {
+    if (this.terminal) {
+      this.setMainBackgroundColor()
+      this.terminal.setOption("theme", getTheme())
+    }
+  }
 }
 
 if (!window.customElements.get("atomic-terminal")) {

--- a/src/model.ts
+++ b/src/model.ts
@@ -246,6 +246,12 @@ export class TerminalModel {
     return this.activeIndex === 0 && (atom.config.get("atomic-terminal.allowHiddenToStayActive") || this.isVisible())
   }
 
+  updateTheme() {
+    if (this.element) {
+      return this.element.updateTheme()
+    }
+  }
+
   setNewPane(pane: Pane) {
     this.pane = pane
     // @ts-ignore

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -36,7 +36,9 @@ class Terminal {
     // Set holding all terminals available at any moment.
     this.terminalsSet = new Set()
 
-    const debounceUpdateTheme = debounce(() => {
+    const debounceUpdateTheme = debounce(async () => {
+      // @ts-ignore
+      await atom.packages.getLoadedPackage("atomic-terminal").reloadStylesheets()
       this.updateTheme()
     })
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -114,7 +114,7 @@ class Terminal {
         TerminalModel.recalculateActive(this.terminalsSet)
       }),
 
-      atom.config.onDidChange("atomic-terminal.toolbarButton", ({ newValue }: {newValue: boolean}) => {
+      atom.config.onDidChange("atomic-terminal.toolbarButton", ({ newValue }: { newValue: boolean }) => {
         if (newValue) {
           addToolbarButton()
         } else {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -36,11 +36,16 @@ class Terminal {
     // Set holding all terminals available at any moment.
     this.terminalsSet = new Set()
 
-    const debounceUpdateTheme = debounce(async () => {
+    const debounceUpdateTheme = debounce(async (style) => {
+      // @ts-ignore
+      if (style.sourcePath.includes("atomic-terminal")) {
+        return
+      }
+
       // @ts-ignore
       await atom.packages.getLoadedPackage("atomic-terminal").reloadStylesheets()
       this.updateTheme()
-    })
+    }, 1)
 
     this.disposables.add(
       // Register view provider for terminal emulator item.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -12,6 +12,16 @@ interface OpenOptions extends WorkspaceOpenOptions {
   pane?: Pane
 }
 
+function debounce(callback: (...args: unknown[]) => void, wait: number = 300) {
+  let timeoutId: NodeJS.Timeout
+  return (...args: unknown[]) => {
+    clearTimeout(timeoutId)
+    timeoutId = setTimeout(() => {
+      callback(...args)
+    }, wait)
+  }
+}
+
 const TERMINAL_BASE_URI = "atomic-terminal://"
 
 class Terminal {
@@ -25,6 +35,10 @@ class Terminal {
 
     // Set holding all terminals available at any moment.
     this.terminalsSet = new Set()
+
+    const debounceUpdateTheme = debounce(() => {
+      this.updateTheme()
+    })
 
     this.disposables.add(
       // Register view provider for terminal emulator item.
@@ -100,13 +114,23 @@ class Terminal {
         TerminalModel.recalculateActive(this.terminalsSet)
       }),
 
-      atom.config.onDidChange("atomic-terminal.toolbarButton", ({ newValue }) => {
+      atom.config.onDidChange("atomic-terminal.toolbarButton", ({ newValue }: {newValue: boolean}) => {
         if (newValue) {
           addToolbarButton()
         } else {
           removeToolbarButton()
         }
       }),
+
+      // Theme changes
+      atom.config.onDidChange("atomic-terminal.colors", () => {
+        // not debounced to update immediately
+        this.updateTheme()
+      }),
+      atom.themes.onDidChangeActiveThemes(debounceUpdateTheme),
+      atom.styles.onDidUpdateStyleElement(debounceUpdateTheme),
+      atom.styles.onDidAddStyleElement(debounceUpdateTheme),
+      atom.styles.onDidRemoveStyleElement(debounceUpdateTheme),
 
       // Add commands.
       // @ts-ignore
@@ -203,6 +227,12 @@ class Terminal {
   exitAllTerminals() {
     for (const terminal of this.terminalsSet) {
       terminal.exit()
+    }
+  }
+
+  updateTheme() {
+    for (const terminal of this.terminalsSet) {
+      terminal.updateTheme()
     }
   }
 

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -180,7 +180,7 @@ export function getTheme(): Record<string, string> {
       break
     }
     default:
-      // do nothing
+    // do nothing
   }
 
   return colors

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -155,15 +155,32 @@ export function getTheme(): Record<string, string> {
       colors.cursor = "#ffffff"
       break
     case "Standard": {
-      if (document.documentElement !== null) {
-        const root = getComputedStyle(document.documentElement)
-        colors.background = root.getPropertyValue("--standard-app-background-color")
-        colors.foreground = root.getPropertyValue("--standard-text-color")
-        colors.selection = root.getPropertyValue("--standard-background-color-selected")
-        colors.cursor = root.getPropertyValue("--standard-text-color-highlight")
-      }
+      const root = getComputedStyle(document.documentElement)
+      colors.background = root.getPropertyValue("--standard-app-background-color")
+      colors.foreground = root.getPropertyValue("--standard-text-color")
+      colors.selection = root.getPropertyValue("--standard-background-color-selected")
+      colors.cursor = root.getPropertyValue("--standard-text-color-highlight")
+
+      colors.black = root.getPropertyValue("--standard-color-black")
+      colors.red = root.getPropertyValue("--standard-color-red")
+      colors.green = root.getPropertyValue("--standard-color-green")
+      colors.yellow = root.getPropertyValue("--standard-color-yellow")
+      colors.blue = root.getPropertyValue("--standard-color-blue")
+      colors.magenta = root.getPropertyValue("--standard-color-magenta")
+      colors.cyan = root.getPropertyValue("--standard-color-cyan")
+      colors.white = root.getPropertyValue("--standard-color-white")
+      colors.brightBlack = root.getPropertyValue("--standard-color-bright-black")
+      colors.brightRed = root.getPropertyValue("--standard-color-bright-red")
+      colors.brightGreen = root.getPropertyValue("--standard-color-bright-green")
+      colors.brightYellow = root.getPropertyValue("--standard-color-bright-yellow")
+      colors.brightBlue = root.getPropertyValue("--standard-color-bright-blue")
+      colors.brightMagenta = root.getPropertyValue("--standard-color-bright-magenta")
+      colors.brightCyan = root.getPropertyValue("--standard-color-bright-cyan")
+      colors.brightWhite = root.getPropertyValue("--standard-color-bright-white")
       break
     }
+    default:
+      // do nothing
   }
 
   return colors

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -17,16 +17,53 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-// The ui-variables file is provided by whatever theme is selected by the
-// user at runtime. See also
-// https://flight-manual.atom.io/hacking-atom/sections/creating-a-theme/#creating-a-ui-theme .
+
+@app-background-color: #000000;
+@text-color: #ffffff;
+@background-color-selected: #4d4d4d;
+@text-color-highlight: #ffffff;
+@terminal-color-black: #2e3436;
+@terminal-color-red: #cc0000;
+@terminal-color-green: #4e9a06;
+@terminal-color-yellow: #c4a000;
+@terminal-color-blue: #3465a4;
+@terminal-color-magenta: #75507b;
+@terminal-color-cyan: #06989a;
+@terminal-color-white: #d3d7cf;
+@terminal-color-bright-black: #555753;
+@terminal-color-bright-red: #ef2929;
+@terminal-color-bright-green: #8ae234;
+@terminal-color-bright-yellow: #fce94f;
+@terminal-color-bright-blue: #729fcf;
+@terminal-color-bright-magenta: #ad7fa8;
+@terminal-color-bright-cyan: #34e2e2;
+@terminal-color-bright-white: #eeeeec;
+
 @import "ui-variables";
+@import "syntax-variables";
 
 :root {
   --standard-app-background-color: @app-background-color;
   --standard-text-color: @text-color;
   --standard-background-color-selected: @background-color-selected;
   --standard-text-color-highlight: @text-color-highlight;
+
+  --standard-color-black: @terminal-color-black;
+  --standard-color-red: @terminal-color-red;
+  --standard-color-green: @terminal-color-green;
+  --standard-color-yellow: @terminal-color-yellow;
+  --standard-color-blue: @terminal-color-blue;
+  --standard-color-magenta: @terminal-color-magenta;
+  --standard-color-cyan: @terminal-color-cyan;
+  --standard-color-white: @terminal-color-white;
+  --standard-color-bright-black: @terminal-color-bright-black;
+  --standard-color-bright-red: @terminal-color-bright-red;
+  --standard-color-bright-green: @terminal-color-bright-green;
+  --standard-color-bright-yellow: @terminal-color-bright-yellow;
+  --standard-color-bright-blue: @terminal-color-bright-blue;
+  --standard-color-bright-magenta: @terminal-color-bright-magenta;
+  --standard-color-bright-cyan: @terminal-color-bright-cyan;
+  --standard-color-bright-white: @terminal-color-bright-white;
 }
 
 // Load the static styles here.


### PR DESCRIPTION
Allow themes to specify terminal colors for standard theme.

```less
@terminal-color-black: #2e3436;
@terminal-color-red: #cc0000;
@terminal-color-green: #4e9a06;
@terminal-color-yellow: #c4a000;
@terminal-color-blue: #3465a4;
@terminal-color-magenta: #75507b;
@terminal-color-cyan: #06989a;
@terminal-color-white: #d3d7cf;
@terminal-color-bright-black: #555753;
@terminal-color-bright-red: #ef2929;
@terminal-color-bright-green: #8ae234;
@terminal-color-bright-yellow: #fce94f;
@terminal-color-bright-blue: #729fcf;
@terminal-color-bright-magenta: #ad7fa8;
@terminal-color-bright-cyan: #34e2e2;
@terminal-color-bright-white: #eeeeec;
```

TODO:
- [x] Tests
- [x] Documentation
- [x] Update on theme change