### PR TITLE
fix: add padding to the terminal

### DIFF
--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -31,3 +31,9 @@
 
 // Load the static styles here.
 @import (less) "../node_modules/xterm/css/xterm.css";
+
+atomic-terminal {
+  .terminal.xterm {
+    padding: 8px;
+  }
+}

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -34,6 +34,6 @@
 
 atomic-terminal {
   .terminal.xterm {
-    padding: 8px;
+    padding: 1rem;
   }
 }


### PR DESCRIPTION
Adds 8 pixels of padding that makes the terminal look better.

![image](https://user-images.githubusercontent.com/16418197/124681876-1ccfc480-de8f-11eb-9fa9-07890103b029.png)


After - With padding (some space):

![image](https://user-images.githubusercontent.com/16418197/125213767-53d01c80-e279-11eb-92c1-b24bb9fcc741.png)

Before - Without padding:

![image](https://user-images.githubusercontent.com/16418197/125213768-5599e000-e279-11eb-830b-501212ae9533.png)


