### PR TITLE
fix: use padding variable

### DIFF
--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -72,5 +72,6 @@
 atomic-terminal {
   .terminal.xterm {
     padding-left: @component-padding;
+    padding-top: @component-padding;
   }
 }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -70,5 +70,7 @@
 @import (less) "../node_modules/xterm/css/xterm.css";
 
 atomic-terminal {
-  padding: @component-icon-padding;
+  .terminal.xterm {
+    padding: @component-padding;
+  }
 }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -70,7 +70,5 @@
 @import (less) "../node_modules/xterm/css/xterm.css";
 
 atomic-terminal {
-  .terminal.xterm {
-    padding: @component-padding;
-  }
+  padding-left: @component-padding;
 }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -70,5 +70,7 @@
 @import (less) "../node_modules/xterm/css/xterm.css";
 
 atomic-terminal {
-  padding-left: @component-padding;
+  .terminal.xterm {
+    padding-left: @component-padding;
+  }
 }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -70,7 +70,5 @@
 @import (less) "../node_modules/xterm/css/xterm.css";
 
 atomic-terminal {
-  .terminal.xterm {
-    padding: @component-icon-padding;
-  }
+  padding: @component-icon-padding;
 }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -71,6 +71,6 @@
 
 atomic-terminal {
   .terminal.xterm {
-    padding: 1rem;
+    padding: @component-icon-padding;
   }
 }


### PR DESCRIPTION
We should use the ui padding variable to be consistent with tree-view and other elements